### PR TITLE
[v0.1.34] Add NODE_ENV variable to GitHub Pages test workflow

### DIFF
--- a/.github/workflows/test-gh-pages.yml
+++ b/.github/workflows/test-gh-pages.yml
@@ -60,6 +60,7 @@ jobs:
           VITE_AUTH_PROXY_URL: https://een-login.klaushofrichter.workers.dev
           TEST_USER: ${{ secrets.TEST_USER }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          NODE_ENV: "production"
         run: |
           echo "🚀 Running tests against Base URL: ${{ env.PLAYWRIGHT_TEST_BASE_URL }}"
           echo "🔒 Using Redirect URI: ${{ env.VITE_REDIRECT_URI }}"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-login",
-  "version": "0.1.33",
-  "lastCommit": "May 10, 2025, 03:47 PM CDT",
+  "version": "0.1.34",
+  "lastCommit": "May 10, 2025, 04:00 PM CDT",
   "private": true,
   "type": "module",
   "base": "/een-login/",


### PR DESCRIPTION
Included the NODE_ENV variable set to "production" in the GitHub Pages test workflow configuration. This addition ensures that the tests run in the correct environment context, enhancing the accuracy and reliability of the testing process.