### PR TITLE
[v0.1.38] Enable Vite server in CI workflow and add echo statement in…

### DIFF
--- a/.github/workflows/test-develop.yml
+++ b/.github/workflows/test-develop.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       VITE_EEN_CLIENT_ID: ${{ secrets.VITE_EEN_CLIENT_ID }}
       VITE_EEN_CLIENT_SECRET: ${{ secrets.VITE_EEN_CLIENT_SECRET }}
-      VITE_AUTH_PROXY_URL: https://een-login.klaushofrichter.workers.dev
+      VITE_REDIRECT_URI: ${{ secrets.VITE_REDIRECT_URI }}
       TEST_USER: ${{ secrets.TEST_USER }}
       TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
       PLAYWRIGHT_TEST_BASE_URL: http://127.0.0.1:3333
@@ -37,13 +37,13 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Start Vite server
-        run: |
-          npm run preview &
-          echo "Waiting for server to start..."
-          while ! nc -z 127.0.0.1 3333; do
-            sleep 1
-          done
+#      - name: Start Vite server
+#        run: |
+#          npm run preview &
+#          echo "Waiting for server to start..."
+#          while ! nc -z 127.0.0.1 3333; do
+#            sleep 1
+#          done
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/.github/workflows/test-develop.yml
+++ b/.github/workflows/test-develop.yml
@@ -37,13 +37,13 @@ jobs:
       - name: Build
         run: npm run build
 
-#      - name: Start Vite server
-#        run: |
-#          npm run preview &
-#          echo "Waiting for server to start..."
-#          while ! nc -z 127.0.0.1 3333; do
-#            sleep 1
-#          done
+      - name: Start Vite server
+        run: |
+          npm run preview &
+          echo "Waiting for server to start..."
+          while ! nc -z 127.0.0.1 3333; do
+            sleep 1
+          done
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "een-login",
-  "version": "0.1.31",
+  "version": "0.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "een-login",
-      "version": "0.1.31",
+      "version": "0.1.38",
       "dependencies": {
         "axios": "^1.6.7",
         "gh-pages": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-login",
-  "version": "0.1.39",
-  "lastCommit": "May 13, 2025, 07:44 PM CDT",
+  "version": "0.1.40",
+  "lastCommit": "May 13, 2025, 07:46 PM CDT",
   "private": true,
   "type": "module",
   "base": "/een-login/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-login",
-  "version": "0.1.37",
-  "lastCommit": "May 10, 2025, 05:12 PM CDT",
+  "version": "0.1.38",
+  "lastCommit": "May 13, 2025, 07:25 PM CDT",
   "private": true,
   "type": "module",
   "base": "/een-login/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-login",
-  "version": "0.1.38",
-  "lastCommit": "May 13, 2025, 07:25 PM CDT",
+  "version": "0.1.39",
+  "lastCommit": "May 13, 2025, 07:44 PM CDT",
   "private": true,
   "type": "module",
   "base": "/een-login/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-login",
-  "version": "0.1.40",
-  "lastCommit": "May 13, 2025, 07:46 PM CDT",
+  "version": "0.1.41",
+  "lastCommit": "May 13, 2025, 08:14 PM CDT",
   "private": true,
   "type": "module",
   "base": "/een-login/",
@@ -17,7 +17,7 @@
     "gh-deploy-help": "gh-pages --help",
     "pre-commit": "npm run version:patch",
     "test": "playwright test",
-    "test-preview": "npm run build && npx playwright test --config playwright.preview.config.js",
+    "test-preview": "npm run build && npx playwright test",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed",
     "test:debug": "playwright test --debug"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,15 +3,15 @@ import { defineConfig, devices } from '@playwright/test'
 // Read base URL from environment variable, default to local dev server
 const baseURL = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://127.0.0.1:3333'
 
-// Define webServer config only when testing locally
-const webServer = baseURL.includes('127.0.0.1')
+// Define webServer config only when NOT in CI (i.e., testing locally)
+const webServer = !process.env.CI
   ? {
       command: 'npm run dev',
       url: 'http://127.0.0.1:3333',
-      reuseExistingServer: !process.env.CI,
-      timeout: 120 * 1000 // Increased timeout for server start
+      reuseExistingServer: true, // Allow reusing if already running locally
+      timeout: 120 * 1000
     }
-  : undefined
+  : undefined; // webServer is undefined in CI, so Playwright won't start one
 
 export default defineConfig({
   testDir: './tests',

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,15 +3,15 @@ import { defineConfig, devices } from '@playwright/test'
 // Read base URL from environment variable, default to local dev server
 const baseURL = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://127.0.0.1:3333'
 
-// Define webServer config only when NOT in CI (i.e., testing locally)
-const webServer = !process.env.CI
+// Define webServer config only when testing locally
+const webServer = baseURL.includes('127.0.0.1')
   ? {
       command: 'npm run dev',
       url: 'http://127.0.0.1:3333',
-      reuseExistingServer: true, // Allow reusing if already running locally
-      timeout: 120 * 1000
+      reuseExistingServer: !process.env.CI,
+      timeout: 120 * 1000 // Increased timeout for server start
     }
-  : undefined; // webServer is undefined in CI, so Playwright won't start one
+  : undefined
 
 export default defineConfig({
   testDir: './tests',

--- a/scripts/slack-test.sh
+++ b/scripts/slack-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 source ../.env
 curl -X POST -H 'Content-type: application/json' --data '{"text":"Hello, een-login!"}' ${SLACK_WEBHOOK_URL}
+echo
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -26,18 +26,18 @@
                   </li>
                   <li>
                     <router-link
-                      to="/settings"
-                      class="text-primary-600 dark:text-primary-400 hover:text-primary-500 dark:hover:text-primary-300"
-                    >
-                      Settings
-                    </router-link>
-                  </li>
-                  <li>
-                    <router-link
                       to="/about"
                       class="text-primary-600 dark:text-primary-400 hover:text-primary-500 dark:hover:text-primary-300"
                     >
                       About
+                    </router-link>
+                  </li>
+                  <li>
+                    <router-link
+                      to="/settings"
+                      class="text-primary-600 dark:text-primary-400 hover:text-primary-500 dark:hover:text-primary-300"
+                    >
+                      Settings
                     </router-link>
                   </li>
                 </ul>

--- a/tests/deep-linking.spec.js
+++ b/tests/deep-linking.spec.js
@@ -26,8 +26,8 @@ test.describe('Deep Linking', () => {
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (baseURL) {
         console.log(`\n🚀 Running tests against Service at URL: ${baseURL}`)
-        console.log(`🔒 Using Auth Proxy URL: ${configuredProxyUrl}\n`)
-        console.log(`🔒 Using Redirect URI: ${redirectUri}\n`)
+        console.log(`🔒 Using Auth Proxy URL: ${configuredProxyUrl}`)
+        console.log(`🔒 Using Redirect URI: ${redirectUri}`)
         console.log(`🔒 Using basePath: ${basePath}\n`)
       }
       loggedBaseURL = true // Set flag so it doesn't log again

--- a/tests/direct-page.spec.js
+++ b/tests/direct-page.spec.js
@@ -22,7 +22,7 @@ test.describe('Direct Page', () => {
       if (baseURL) {
         console.log(`\n🚀 Running tests against Service at URL: ${baseURL}`)
         console.log(`🔒 Using Auth Proxy URL: ${configuredProxyUrl}`)
-        console.log(`🔒 Using Redirect URI: ${redirectUri}\)
+        console.log(`🔒 Using Redirect URI: ${redirectUri}`)
         console.log(`🔒 Using basePath: ${basePath}\n`)
       }
       loggedBaseURL = true // Set flag so it doesn't log again

--- a/tests/direct-page.spec.js
+++ b/tests/direct-page.spec.js
@@ -21,8 +21,8 @@ test.describe('Direct Page', () => {
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (baseURL) {
         console.log(`\n🚀 Running tests against Service at URL: ${baseURL}`)
-        console.log(`🔒 Using Auth Proxy URL: ${configuredProxyUrl}\n`)
-        console.log(`🔒 Using Redirect URI: ${redirectUri}\n`)
+        console.log(`🔒 Using Auth Proxy URL: ${configuredProxyUrl}`)
+        console.log(`🔒 Using Redirect URI: ${redirectUri}\)
         console.log(`🔒 Using basePath: ${basePath}\n`)
       }
       loggedBaseURL = true // Set flag so it doesn't log again

--- a/tests/invalid-route.spec.js
+++ b/tests/invalid-route.spec.js
@@ -20,8 +20,8 @@ test.describe('Invalid Route Navigation', () => {
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (baseURL) {
         console.log(`\n🚀 Running tests against Service at URL: ${baseURL}`)
-        console.log(`🔒 Using Auth Proxy URL: ${configuredProxyUrl}\n`)
-        console.log(`🔒 Using Redirect URI: ${redirectUri}\n`)
+        console.log(`🔒 Using Auth Proxy URL: ${configuredProxyUrl}`)
+        console.log(`🔒 Using Redirect URI: ${redirectUri}`)
         console.log(`🔒 Using basePath: ${basePath}\n`)
       }
       loggedBaseURL = true // Set flag so it doesn't log again

--- a/tests/token-revocation.spec.js
+++ b/tests/token-revocation.spec.js
@@ -6,7 +6,6 @@ import {
   navigateToLogin,
   loginToApplication, 
   logoutFromApplication, 
-  isGitHubPagesEnvironment,
   getLastPartOfUrl
 } from './utils'
 
@@ -28,8 +27,8 @@ test.describe('Token Revocation', () => {
       // eslint-disable-next-line playwright/no-conditional-in-test
       if (baseURL) {
         console.log(`\n🚀 Running tests against Service at URL: ${baseURL}`)
-        console.log(`🔒 Using Auth Proxy URL: ${configuredProxyUrl}\n`)
-        console.log(`🔒 Using Redirect URI: ${redirectUri}\n`)
+        console.log(`🔒 Using Auth Proxy URL: ${configuredProxyUrl}`)
+        console.log(`🔒 Using Redirect URI: ${redirectUri}`)
         console.log(`🔒 Using basePath: ${basePath}\n`)
       }
       loggedBaseURL = true // Set flag so it doesn't log again


### PR DESCRIPTION
… Slack test script

Updated the GitHub Actions workflow to enable the Vite server during the testing process, ensuring that the server starts correctly before running Playwright tests. Additionally, added an echo statement in the Slack test script for improved output clarity. These changes enhance the testing environment and provide better feedback during execution.