### PR TITLE
Refactor README link handling in tests to use package name from packa…

### DIFF
--- a/tests/direct-page.spec.js
+++ b/tests/direct-page.spec.js
@@ -2,6 +2,7 @@
 import { test, expect } from '@playwright/test'
 import dotenv from 'dotenv'
 import { isGitHubPagesEnvironment, buildUrl, getLastPartOfUrl } from './utils.js'
+import pkg from '../package.json' assert { type: 'json' }
 
 // Load environment variables from .env file
 dotenv.config()
@@ -88,8 +89,8 @@ test.describe('Direct Page', () => {
     const isDev = process.env.NODE_ENV !== 'production'
     // eslint-disable-next-line playwright/no-conditional-in-test
     const expectedReadmeHref = isDev
-      ? 'https://github.com/klaushofrichter/een-login/blob/develop/README.md'
-      : 'https://github.com/klaushofrichter/een-login/blob/gh-pages/README.md'
+      ? `https://github.com/klaushofrichter/${pkg.name}/blob/develop/README.md`
+      : `https://github.com/klaushofrichter/${pkg.name}/blob/gh-pages/README.md`
     await expect(readme).toHaveAttribute('href', expectedReadmeHref)
     console.log('✅ README link verified')
     console.log('✅ Direct page test completed successfully')

--- a/tests/login-page.spec.js
+++ b/tests/login-page.spec.js
@@ -5,6 +5,7 @@ import { navigateToHome, isGitHubPagesEnvironment } from './utils'
 
 // Load environment variables from .env file
 dotenv.config()
+import pkg from '../package.json' assert { type: 'json' }
 
 let loggedBaseURL = false // Flag to ensure baseURL is logged only once
 
@@ -70,14 +71,14 @@ test.describe('Login Page', () => {
 
     // eslint-disable-next-line playwright/no-conditional-in-test
     let isDev = process.env.NODE_ENV !== 'production'
-    if(process.env.PLAYWRIGHT_TEST_BASE_URL === 'https://klaushofrichter.github.io/een-login') 
+    if(process.env.PLAYWRIGHT_TEST_BASE_URL === `https://klaushofrichter.github.io/${pkg.name}`) 
       isDev=false  // because we use the deployed app version on GitHub Pages
 
     // eslint-disable-next-line playwright/no-conditional-in-test
     const expectedReadmeHref = isDev
-      ? 'https://github.com/klaushofrichter/een-login/blob/develop/README.md'
-      : 'https://github.com/klaushofrichter/een-login/blob/gh-pages/README.md'
-    await expect(readme).toHaveAttribute('href', expectedReadmeHref)
+      ? `https://github.com/klaushofrichter/${pkg.name}/blob/develop/README.md`
+      : `https://github.com/klaushofrichter/${pkg.name}/blob/gh-pages/README.md`
+  await expect(readme).toHaveAttribute('href', expectedReadmeHref)
     console.log('✅ README link verified')
     console.log('✅ Login page test completed successfully')
   })


### PR DESCRIPTION
…ge.json

Updated direct-page.spec.js and login-page.spec.js to dynamically construct README links using the package name from package.json. This change enhances maintainability and ensures that the links remain accurate regardless of future package name changes.