### PR TITLE
[v0.1.71] Refactor Slack notification workflow to correct last commit…

### DIFF
--- a/.github/workflows/slack-test-notification.yml
+++ b/.github/workflows/slack-test-notification.yml
@@ -21,13 +21,10 @@ jobs:
         run: |
           # Get the version from the same commit that was tested
           VERSION=$(node -p 'require("./package.json").version')
-          LAST_COMMIT=$(node -p 'require("./package.json").last_commit')
-          BRANCH=$(node -p 'require("./package.json").branch')
+          LAST_COMMIT=$(node -p 'require("./package.json").lastCommit')
           cat package.json
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "LAST_COMMIT=$LAST_COMMIT" >> $GITHUB_OUTPUT
-          echo "BRANCH=$BRANCH" >> $GITHUB_OUTPUT
-          echo "Branch: $BRANCH"
           echo "Last Commit: $LAST_COMMIT"
           echo "Version: $VERSION"
 
@@ -86,8 +83,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": 
-                      *Repository:* <https://github.com/${{ github.repository }}|${{ github.repository }}\n*Branch:* <https://github.com/${{ github.repository }}/tree/${{ github.event.workflow_run.head_branch }}|${{ github.event.workflow_run.head_branch }}\n*Build Date:* ${{ steps.package-version.outputs.LAST_COMMIT }} UTC"
+                    "text": "*Repository:* <https://github.com/${{ github.repository }}|${{ github.repository }}\n*Branch:* <https://github.com/${{ github.repository }}/tree/${{ github.event.workflow_run.head_branch }}|${{ github.event.workflow_run.head_branch }}\n*Build Date:* ${{ steps.package-version.outputs.LAST_COMMIT }}"
                   }
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-login",
-  "version": "0.1.70",
-  "lastCommit": "2025-05-17T14:56:41.081Z",
+  "version": "0.1.71",
+  "lastCommit": "2025-05-17T15:06:36.877Z",
   "private": true,
   "type": "module",
   "base": "/een-login/",


### PR DESCRIPTION
… variable name

Updated the Slack notification workflow to change the variable name for the last commit from `last_commit` to `lastCommit` in the package.json extraction. Removed the branch information output to streamline the notification message, ensuring clarity and consistency in the displayed information.