### PR TITLE
[v0.1.79] Increase timeout for token revocation test from 30 seconds …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "een-login",
-  "version": "0.1.78",
-  "lastCommit": "2025-05-18T20:04:47.595Z",
+  "version": "0.1.79",
+  "lastCommit": "2025-05-21T22:57:19.969Z",
   "private": true,
   "type": "module",
   "base": "/een-login/",

--- a/tests/token-revocation.spec.js
+++ b/tests/token-revocation.spec.js
@@ -44,7 +44,7 @@ test.describe('Token Revocation', () => {
     console.log(
       '  The logout again without cancelation, and go to the direct page and enters the access token to check if it is revoked. '
     )
-    test.setTimeout(30000) // 30 sec max for this test
+    test.setTimeout(60000) // 60 sec max for this test
 
     // go directly to the home page
     await navigateToLogin(page, basePath)


### PR DESCRIPTION
…to 60 seconds to accommodate longer execution times.